### PR TITLE
#48 add backend-frontend connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /public
 /node_modules
+/dist
 
 # Logs
 logs

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ install:
 	npm install
 
 start:
-	npx nodos server
+	npm run build
+	npm run start
+
+front-dev:
+	npm run serve
 
 build:
 	npm run build

--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ make install
 
 ```bash
 make start
+```
 
 localhost:3000
+
+## Develop frontend
+
+```bash
+make front-dev
 ```
+
+localhost:8080
 
 ## How to help
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config __test__/jest-e2e.json",
     "build:dev": "webpack --mode=development",
-    "build:prod": "webpack --mode=production --node-env=production",
     "watch": "webpack --watch",
     "serve": "webpack serve"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,11 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.useStaticAssets(join(__dirname, '..', 'public/assets'));
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
1. Сделана связка бэкенда и фронтенда - чтобы сервер отдавал реакт-приложение, собранное вебпаком.
2. Добавлены команды в Makefile
make start - сначала запускается сборка фронтенд-приложения вебпаком, затем запускается сервер
make front-dev - запускается вебпаковский сервер, фронтенд удобнее разрабатывать через него, т.к. серверное приложение пока само не обновляется при изменении файлов
3. В ридми добавлено описание команды make front-dev
4. Папка /dist (nest собирает туда свое приложение) добавлена в .gitignore
5. В package.json были две одинаковые команды - одна убрана