### PR TITLE
[#102] fix compile routing and request

### DIFF
--- a/app/javascript/slices/terminalSlice.js
+++ b/app/javascript/slices/terminalSlice.js
@@ -5,7 +5,8 @@ import axios from 'axios';
 export const runCode = createAsyncThunk(
   'terminal/runCode',
   async (code) => {
-    const { data, status } = await axios.get(`/compile?code=${code}`);
+    const { data, status } = await axios.get(`/compile`, { params: { code } });
+
     if (status === 200) return data;
     return 'Connection issues';
   },

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,13 @@
-/* eslint-disable no-useless-constructor */
 /* eslint-disable class-methods-use-this */
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
+
+  @Get('compile')
+  getLogs(@Query() query: any): string {
+    return this.appService.run(query.code);
+  }
 }


### PR DESCRIPTION
### Предпосылки:
В консоль Hexlet-Editor вместо вывода результата работы кода выводился HTML код.

### Изменения:
- Пофикшен запуск кода на сервере.
- Поправлена передача кода на сервер (при передаче терялись символы перевода строки, знак "+" и т.д, теперь - нет).
