### PR TITLE
Add "I forgot my password" page, fix ui layout for signup page.

### DIFF
--- a/app/javascript/Pages/RemindPassword.jsx
+++ b/app/javascript/Pages/RemindPassword.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useEffect, useRef } from 'react';
 import * as yup from 'yup';
 import { useFormik } from 'formik';

--- a/app/javascript/Pages/RemindPassword.jsx
+++ b/app/javascript/Pages/RemindPassword.jsx
@@ -31,7 +31,7 @@ export const RemindPassword = () => {
   return (
     <Container fluid className="h-100">
       <Row className="justify-content-center align-content-center h-100">
-        <Col xs={12} md={8} xxl={6}>
+        <Col xs={12} md={8} xxl={5} className="mt-5">
           <Card className="shadow-sm">
             <Card.Body className="p-lg-4 p-xl-5">
               <h1 className="mb-4 fw-light">{t('remindPass.pageHeader')}</h1>

--- a/app/javascript/Pages/RemindPassword.jsx
+++ b/app/javascript/Pages/RemindPassword.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef } from 'react';
+import * as yup from 'yup';
+import { useFormik } from 'formik';
+import { Container, Card, Col, Row, Form, Button } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+
+export const RemindPassword = () => {
+  const inputRef = useRef();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    inputRef.current.focus();
+  },[]);
+
+  const emailValidation = yup.object().shape({
+    email: yup.string().email(t('remindPass.emailValidation')),
+  });
+
+  const formik = useFormik({
+    initialValues: {
+      email: '',
+    },
+    validationSchema: emailValidation,
+    onSubmit: (values) => {
+      console.log(values);
+    },
+  });
+
+  const { handleBlur, handleChange, handleSubmit, values } = formik;
+  return (
+    <Container fluid className="h-100">
+      <Row className="justify-content-center align-content-center h-100">
+        <Col xs={12} md={8} xxl={6}>
+          <Card className="shadow-sm">
+            <Card.Body className="p-lg-4 p-xl-5">
+              <h1 className="mb-4 fw-light">{t('remindPass.pageHeader')}</h1>
+              <div className="pt-lg-3">
+                <Form onSubmit={handleSubmit} noValidate>
+                  <Form.Group className="mb-4">
+                    <Form.Label htmlFor="email">{t('remindPass.email')}</Form.Label>
+                    <Form.Control
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    value={values.email}
+                    className="form-input"
+                    name="email"
+                    id="email"
+                    autoComplete="email"
+                    required
+                    ref={inputRef}
+                    />
+                  </Form.Group>
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    className="w-100"
+                  >
+                    {t('remindPass.reset')}
+                  </Button>
+                </Form>
+              </div>
+            </Card.Body>
+            <Card.Footer className="border-top-0 text-center py-4">
+              <div className="py-lg-2">
+                <div className="small">
+                  <span className="text-muted">{t('remindPass.signUpHeader')}</span>
+                  <a className="link-dark" href="signup">{t('remindPass.signUp')}</a>
+                </div>
+                <div className="small">
+                  <span className="text-muted">{t('remindPass.signInHeader')}</span>
+                  <a className="link-dark" href="login">{t('remindPass.signIn')}</a>
+                </div>
+              </div>
+            </Card.Footer>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
+};

--- a/app/javascript/Pages/SignIn.jsx
+++ b/app/javascript/Pages/SignIn.jsx
@@ -1,11 +1,16 @@
 /* eslint-disable no-console */
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import axios from 'axios';
 import { Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { useFormik } from 'formik';
 
 export function SignIn() {
+  const inputRef = useRef();
   const [authFailed, setAuthFailed] = useState(false);
+
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
 
   const formik = useFormik({
     initialValues: {
@@ -48,6 +53,7 @@ export function SignIn() {
                       autoComplete="email"
                       required
                       isInvalid={authFailed}
+                      ref={inputRef}
                     />
                   </Form.Group>
                   <Form.Group className="mb-3">

--- a/app/javascript/Pages/SignIn.jsx
+++ b/app/javascript/Pages/SignIn.jsx
@@ -35,7 +35,7 @@ export function SignIn() {
   return (
     <Container fluid className="h-100">
       <Row className="justify-content-center align-content-center h-100">
-        <Col xs={12} md={8} xxl={6}>
+        <Col xs={12} md={8} xxl={5} className="mt-5">
           <Card className="shadow-sm">
             <Card.Body className="p-lg-4 p-xl-5">
               <h1 className="mb-4 fw-light">Вход</h1>

--- a/app/javascript/Pages/SignIn.jsx
+++ b/app/javascript/Pages/SignIn.jsx
@@ -77,7 +77,7 @@ export function SignIn() {
                   <Button
                     type="submit"
                     variant="primary"
-                    className="w-100 btn-primary"
+                    className="w-100"
                     data-disable-with="Войти"
                   >
                     Войти

--- a/app/javascript/Pages/SignIn.jsx
+++ b/app/javascript/Pages/SignIn.jsx
@@ -76,7 +76,7 @@ export function SignIn() {
                     </Form.Control.Feedback>
                   </Form.Group>
                   <div className="text-end my-3">
-                    <a className="text-decoration-none small" href="/">
+                    <a className="text-decoration-none small" href="remind_password">
                       Не помню пароль
                     </a>
                   </div>

--- a/app/javascript/Pages/SignUp.jsx
+++ b/app/javascript/Pages/SignUp.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable react/function-component-definition */
 /* eslint-disable no-console */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as yup from 'yup';
 import { useFormik } from 'formik';
 import {
@@ -17,7 +17,13 @@ import {
 import { useTranslation } from 'react-i18next';
 
 export const SignUp = () => {
+  const inputRef = useRef();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
+
   const signUpValidation = yup.object().shape({
     name: yup
       .string()
@@ -68,6 +74,7 @@ export const SignUp = () => {
                         {t('signUp.email')} <span>*</span>
                       </FormLabel>
                       <FormControl
+                        ref={inputRef}
                         type="text"
                         autoFocus="autofocus"
                         name="email"

--- a/app/javascript/Pages/SignUp.jsx
+++ b/app/javascript/Pages/SignUp.jsx
@@ -62,7 +62,7 @@ export const SignUp = () => {
   return (
     <Container fluid className="h-100">
       <Row className="justify-content-center align-content-center h-100">
-        <Col xs={12} md={8} xxl={6}>
+        <Col xs={12} md={8} xxl={5} className="mt-5">
           <div className="pb-lg-5">
             <Card className="shadow-sm">
               <Card.Body className="p-lg-4 p-xl-5">

--- a/app/javascript/Pages/SignUp.jsx
+++ b/app/javascript/Pages/SignUp.jsx
@@ -54,12 +54,12 @@ export const SignUp = () => {
   });
   const { handleBlur, handleChange, handleSubmit, values } = formik;
   return (
-    <Container>
-      <Row>
-        <Col className="col-md-6 py-5">
+    <Container fluid className="h-100">
+      <Row className="justify-content-center align-content-center h-100">
+        <Col xs={12} md={8} xxl={6}>
           <div className="pb-lg-5">
             <Card className="shadow-sm">
-              <Card.Body>
+              <Card.Body className="p-lg-4 p-xl-5">
                 <h1 className="mb-4 fw-light">{t('signUp.pageHeader')}</h1>
                 <div className="pt-lg-3">
                   <Form onSubmit={handleSubmit}>
@@ -119,7 +119,13 @@ export const SignUp = () => {
                         value={values.confirmPassword}
                       />
                     </div>
-                    <Button type="submit">{t('signUp.register')}</Button>
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      className="w-100 mt-4"
+                    >
+                      {t('signUp.register')}
+                    </Button>
                   </Form>
                 </div>
               </Card.Body>

--- a/app/javascript/RoutesInit.jsx
+++ b/app/javascript/RoutesInit.jsx
@@ -5,6 +5,7 @@ import { Profile } from './Pages/Profile.jsx';
 import { SignUp } from './Pages/SignUp.jsx';
 import { SignIn } from './Pages/SignIn.jsx';
 import { About } from './Pages/About.jsx';
+import { RemindPassword } from './Pages/RemindPassword.jsx';
 
 function RoutesInit() {
   return (
@@ -14,6 +15,7 @@ function RoutesInit() {
       <Route path="profile" element={<Profile />} />
       <Route path="signup" element={<SignUp />} />
       <Route path="login" element={<SignIn />} />
+      <Route path="remind_password" element={<RemindPassword />} />
       <Route path="*" element={<div>Page Not Found</div>} />
     </Routes>
   );

--- a/app/javascript/locales/ru.js
+++ b/app/javascript/locales/ru.js
@@ -11,6 +11,16 @@ const ruLocales = {
       confirmUserPassword: 'Подтверждение пароля',
       register: 'Зарегистрироваться',
     },
+    remindPass: {
+      pageHeader: 'Забыли пароль?',
+      emailValidation: 'Неправильный email',
+      email: 'Электронная почта',
+      reset: 'Восстановить пароль',
+      signUpHeader: 'Нет аккаунта? ',
+      signUp: 'Создать бесплатный аккаунт',
+      signInHeader: 'Уже есть аккаунт? ',
+      signIn: 'Войти',
+    }
   },
 };
 


### PR DESCRIPTION
- Made "sign up" page look the same as "sign in" page
- Added ref attribute to the first input field of "sign up" page to focus on it when loaded as a good UX practice
- Added ref attribute to the first input field of "sign in" page to focus on it when loaded as a good UX practice
- Removed "btn-primary" class from <button> component on "sign in" page as it already gets this class from "variant=primary" property, thus we removed class duplication
- Added "remind password" page
- Added route to "remind password" page in RoutesInit.jsx
- Added locales for "remind password" page
- Added href to "remind password" page from "sign in" page
#125